### PR TITLE
Allow setting density=True for histograms with a log or logicle scale

### DIFF
--- a/cytoflow/views/histogram.py
+++ b/cytoflow/views/histogram.py
@@ -87,8 +87,7 @@ class HistogramView(Base1DView):
             
         density: bool
             If `True`, re-scale the histogram to form a probability density
-            function, so the area under the histogram is 1.  Only seems to 
-            work if `scale` is `linear`.
+            function, so the area under the histogram is 1.
             
         orientation : {'horizontal', 'vertical'}
             The orientation of the histogram.  `horizontal` gives a histogram
@@ -195,7 +194,14 @@ class HistogramView(Base1DView):
                 x = x[x < bins[-1]]
                 new_args.append(x)
                 
-            n, _, _ = plt.hist(*new_args, **kwargs)
+            if scale.name == "log" and kwargs.get("density"):
+                kwargs["density"] = False
+                counts, _ = np.histogram(new_args, bins=kwargs["bins"])
+                kwargs["weights"] = counts / np.sum(counts)
+                n, _, _ = plt.hist(kwargs["bins"][:-1], **kwargs)
+            else:
+                n, _, _ = plt.hist(*new_args, **kwargs)
+
             count_max.append(max(n))
                     
         grid.map(hist_lims, self.channel, **kwargs)

--- a/cytoflow/views/histogram.py
+++ b/cytoflow/views/histogram.py
@@ -194,7 +194,7 @@ class HistogramView(Base1DView):
                 x = x[x < bins[-1]]
                 new_args.append(x)
                 
-            if scale.name == "log" and kwargs.get("density"):
+            if scale.name != "linear" and kwargs.get("density"):
                 kwargs["density"] = False
                 counts, _ = np.histogram(new_args, bins=kwargs["bins"])
                 kwargs["weights"] = counts / np.sum(counts)


### PR DESCRIPTION
The trick is to pre-calculate the histogram weights and use `plt.hist` just for plotting.

Works with log:
![Screenshot_20201225_123710](https://user-images.githubusercontent.com/2568856/103141812-ab78b300-46ae-11eb-9912-de3c2610e625.png)

As well as logicle:
![Screenshot_20201225_123723](https://user-images.githubusercontent.com/2568856/103141813-ac114980-46ae-11eb-8d04-4f637002d9b4.png)

A bit easier to see (and more useful) if the two things have an unequal number of event counts:
![Screenshot_20201225_124524](https://user-images.githubusercontent.com/2568856/103141852-470a2380-46af-11eb-9472-e17e747f37e5.png)

I've been using this feature a bunch -- don't have to calculate KDEs to compare to conditions with unequal event counts.